### PR TITLE
Fix: Excluir al header y al footer de la animación de transiciones de página

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -21,15 +21,14 @@ export default function Footer() {
 
   return (
     <div className={style.container}>
-      <div className={style.sample_logo}>
-        <img
-          className={style.logo_ong}
-          src={'/images/assets/logo1.png'}
-          alt="Logo ONG"
-        />
-      </div>
-      <hr className={style.rectangle_top} />
       <div className={style.footer_navigation}>
+        <div className={style.sample_logo}>
+          <img
+            className={style.logo_ong}
+            src={'/images/assets/logo1.png'}
+            alt="Logo ONG"
+          />
+        </div>
         <p className={style.information}>
           <a href="/">Inicio</a>
         </p>
@@ -49,7 +48,6 @@ export default function Footer() {
           <a href="/contact">Contacto</a>
         </p>
       </div>
-      <hr className={style.rectangle_bottom} />
       <div className={style.icons}>
         {info
           .filter(val => val.id === 8)

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,188 +1,92 @@
 .container {
-    position: relative;
-    width: 1680px;
-    height: 501px;
-    background-color: #ffffff;
+  position: relative;
+  display: flex;
+  flex-flow: wrap;
+  justify-content: center;
+  align-items: center;
+  height: 500px;
 }
 
 /* Rectangle */
-.rectangle_top {
-    position: absolute;
-    width: 1680px;
-    height: 3px;
-    left: 0px;
-    top: 37px;
-    background: rgba(0, 0, 0, 0.5);
+
+.footer_navigation {
+  display: flex;
+  flex-flow: wrap;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
 }
 
-.footer_navigation p a {
-    text-decoration: none;
-    color: inherit;
+.footer_navigation a {
+  text-decoration: none;
+  font-weight: 700;
+  color: inherit;
 }
 
-/* Contacto */
-.contact {
-    position: absolute;
-    width: 173px;
-    height: 24px;
-    left: 1427px;
-    top: 120px;
-    font-family: 'Montserrat';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 15px;
-    line-height: 24px;
-    text-align: right;
-    letter-spacing: -0.015em;
-    color: #000000;
+.footer_navigation a:hover {
+  text-decoration: underline;
 }
 
-/* Nosotros */
-.us {
-    position: absolute;
-    width: 173px;
-    height: 24px;
-    left: 1236px;
-    top: 120px;
-    font-family: 'Montserrat';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 15px;
-    line-height: 24px;
-    text-align: right;
-    letter-spacing: -0.015em;
-    color: #000000;
-}
-
-/* Testimonios */
-.testimonial {
-    position: absolute;
-    width: 173px;
-    height: 24px;
-    left: 1043px;
-    top: 120px;
-    font-family: 'Montserrat';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 15px;
-    line-height: 24px;
-    text-align: right;
-    letter-spacing: -0.015em;
-    color: #000000;
-}
-
-/* Novedades */
-.news {
-    position: absolute;
-    width: 173px;
-    height: 24px;
-    left: 464px;
-    top: 120px;
-    font-family: 'Montserrat';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 15px;
-    line-height: 24px;
-    letter-spacing: -0.015em;
-    color: #000000;
-}
-
-/* Actividades */
-.activities {
-    position: absolute;
-    width: 173px;
-    height: 24px;
-    left: 273px;
-    top: 120px;
-    font-family: 'Montserrat';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 15px;
-    line-height: 24px;
-    letter-spacing: -0.015em;
-    color: #000000;
-}
-
-/* Noticias */
 .information {
-    position: absolute;
-    width: 173px;
-    height: 24px;
-    left: 80px;
-    top: 120px;
-    font-family: 'Montserrat';
-    font-style: normal;
-    font-weight: 700;
-    font-size: 15px;
-    line-height: 24px;
-    letter-spacing: -0.015em;
-    color: #000000;
+  order: 1;
 }
 
-/* Sample Logo */
+.activities {
+  order: 2;
+}
+
+.news {
+  order: 3;
+}
+
 .sample_logo {
-    position: absolute;
-    width: 122.07px;
-    height: 32px;
-    left: 728px;
-    top: 120px;
+  order: 0;
+  width: 100%;
+  text-align: center;
 }
 
-/* LOGO ONG */
-.logo_ong {
-    position: absolute;
-    right: -80%;
-    top: -250%;
-    font-family: 'Comfortaa';
-    font-style: normal;
-    font-weight: 400;
-    font-size: 28.4444px;
-    line-height: 32px;
-    display: flex;
-    align-items: center;
-    text-align: center;
-    letter-spacing: -0.015em;
-    color: #000000;
+.testimonial {
+  order: 5;
 }
 
-/* Rectangle Bottom */
-.rectangle_bottom {
-    position: absolute;
-    width: 1520px;
-    height: 1px;
-    left: 80px;
-    top: 192px;
-    background: rgba(0, 0, 0, 0.5);
+.us {
+  order: 6;
 }
 
-/* 2022 by Alkemy. All Rights Reserved. */
-.info_alkemy {
-    position: absolute;
-    width: 301px;
-    height: 24px;
-    left: 690px;
-    top: 357px;
-    font-family: 'Montserrat';
-    font-style: normal;
-    font-weight: 400;
-    font-size: 15px;
-    line-height: 24px;
-    text-align: center;
-    letter-spacing: -0.015em;
-    color: rgba(0, 0, 0, 0.8);
+.contact {
+  order: 7;
 }
 
 /* Iconos y tamaños */
 .icons {
-    position: absolute;
-    top: 279px;
-    left: 670px;
+  top: 279px;
+  left: 670px;
 }
 .icons a {
-    text-decoration: none;
+  text-decoration: none;
 }
 .icons_size {
-    height: 44px;
-    width: 44px;
-    margin-left: 21px;
+  height: 44px;
+  width: 44px;
+  margin-left: 21px;
+}
+
+.info_alkemy {
+  width: 100%;
+  text-align: center;
+}
+
+@media (min-width: 992px) {
+  .footer_navigation {
+    gap: var(--spacing-10);
+  }
+
+  .sample_logo {
+    order: 4;
+    width: auto;
+  }
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -69,12 +69,12 @@
 
 .dropdownmenu {
   display: none;
-  width: 130px;
+  min-width: 130px;
   position: absolute;
   top: 60px;
   list-style: none;
   text-align: center;
-  right: 0;
+  right: var(--spacing-4);
   opacity: 0.8;
   z-index: 2;
 }
@@ -95,19 +95,21 @@
   position: absolute;
   right: 0;
   top: 30px;
+  right: var(--spacing-4);
   text-align: start;
-  width: 130px;
+  width: 100px;
   height: 30px;
   display: none;
+  cursor: pointer;
 }
 
 .iconclicked {
   display: none;
   position: absolute;
-  right: 0;
+  right: var(--spacing-4);
   top: 30px;
   text-align: start;
-  width: 130px;
+  width: 100px;
   background-color: #1888ff;
   height: 30px;
   opacity: 0.8;
@@ -281,18 +283,15 @@
 
   .dropdownmenu {
     display: block;
-    left: 80%;
-    width: 100px;
-    text-align: end;
+    min-width: 100px;
   }
 
   .iconmenu {
     display: flex;
-    left: 80%;
+    width: 100px;
   }
   .iconclicked {
     display: block;
-    left: 80%;
     width: 100px;
   }
 

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -1,13 +1,11 @@
 import HelloUser from '../HelloUser/HelloUser';
 import Carousel from '../carousel/Carousel';
-import Footer from '../Footer/Footer';
 
 const Home = () => {
   return (
     <>
       <Carousel />
       <HelloUser username={undefined} />
-      <Footer />
     </>
   );
 };

--- a/src/layout/OutletLayout.js
+++ b/src/layout/OutletLayout.js
@@ -1,20 +1,23 @@
-import { Outlet } from "react-router-dom";
-import Header from "../components/Header/Header";
+import { Outlet } from 'react-router-dom';
 import { HeaderLinks } from '../constants/HeaderLinks-Home';
+import Header from '../components/Header/Header';
+import Footer from '../components/Footer/Footer';
 import PageTransition from '../components/PageTransition/PageTransition';
 
 const OutletLayout = () => {
-
-    return (
-        <PageTransition>
-            <Header
-                logo={'/images/assets/logo1.png'}
-                menu={HeaderLinks}
-                buttons={true}
-            />
-            <Outlet />
-        </PageTransition>
-    )
-}
+  return (
+    <>
+      <Header
+        logo={'/images/assets/logo1.png'}
+        menu={HeaderLinks}
+        buttons={true}
+      />
+      <PageTransition>
+        <Outlet />
+      </PageTransition>
+      <Footer />
+    </>
+  );
+};
 
 export default OutletLayout;

--- a/src/layout/OutletLayoutSecondary.js
+++ b/src/layout/OutletLayoutSecondary.js
@@ -1,19 +1,16 @@
-import { Outlet } from "react-router-dom";
-import Header from "../components/Header/Header";
+import { Outlet } from 'react-router-dom';
+import Header from '../components/Header/Header';
 import PageTransition from '../components/PageTransition/PageTransition';
 
 const OutletLayoutSecondary = () => {
+  return (
+    <>
+      <Header logo={'/images/assets/logo1.png'} menu={[]} />
+      <PageTransition>
+        <Outlet />
+      </PageTransition>
+    </>
+  );
+};
 
-    return (
-        <PageTransition>
-            <Header
-                logo={'/images/assets/logo1.png'}
-                menu={[]}
-            />
-            <Outlet />
-        </PageTransition>
-    )
-
-}
-
-export default OutletLayoutSecondary
+export default OutletLayoutSecondary;


### PR DESCRIPTION
### Este pull request:

- Excluye al `Header` de la animación de transición en el componente `OutletLayout`.
- Agrega al `Footer` como un componente global junto al `Header` en el `OutletLayout`.
- Cambia los estilos del `Footer` para que se adapte a los distintos dispositivos

### Evidencia:

#### Transición de páginas:

![Transición de páginas](https://user-images.githubusercontent.com/59775390/169914013-558933df-9509-497b-a2a7-aef7b06fc874.gif)

#### Footer mobile:

![Footer mobile](https://user-images.githubusercontent.com/59775390/169914045-c5335ecd-8332-4a7a-b1de-f5a88f775cba.png)

#### Footer desktop:

![Footer desktop](https://user-images.githubusercontent.com/59775390/169914072-75782c08-9461-4c90-8b0d-1a32f1b80606.png)

.